### PR TITLE
Unit test TTLReportReconciler controller

### DIFF
--- a/pkg/vulnerabilityreport/ttl_report.go
+++ b/pkg/vulnerabilityreport/ttl_report.go
@@ -2,8 +2,8 @@ package vulnerabilityreport
 
 import (
 	"context"
-	"fmt"
 	"time"
+	"fmt"
 
 	"github.com/aquasecurity/trivy-operator/pkg/ext"
 	"github.com/aquasecurity/trivy-operator/pkg/utils"
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type TTLReportReconciler struct {
@@ -45,10 +46,15 @@ func (r *TTLReportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *TTLReportReconciler) reconcileReport() reconcile.Func {
 	return func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-		log := r.Logger.WithValues("report", req.NamespacedName)
+		return r.DeleteReportIfExpired(ctx, req.NamespacedName)
+	}
+}
+
+func (r *TTLReportReconciler) DeleteReportIfExpired(ctx context.Context, namespacedName types.NamespacedName) (ctrl.Result, error) {
+		log := r.Logger.WithValues("report", namespacedName)
 
 		report := &v1alpha1.VulnerabilityReport{}
-		err := r.Client.Get(ctx, req.NamespacedName, report)
+		err := r.Client.Get(ctx, namespacedName, report)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				log.V(1).Info("Ignoring cached report that must have been deleted")
@@ -79,5 +85,4 @@ func (r *TTLReportReconciler) reconcileReport() reconcile.Func {
 		}
 		log.V(1).Info("RequeueAfter", "durationToTTLExpiration", durationToTTLExpiration)
 		return ctrl.Result{RequeueAfter: durationToTTLExpiration}, nil
-	}
 }

--- a/pkg/vulnerabilityreport/ttl_report_test.go
+++ b/pkg/vulnerabilityreport/ttl_report_test.go
@@ -1,0 +1,138 @@
+package vulnerabilityreport_test
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/ext"
+	"github.com/aquasecurity/trivy-operator/pkg/operator/etc"
+	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+	"github.com/aquasecurity/trivy-operator/pkg/vulnerabilityreport"
+)
+
+const (
+	vreport = "vreport"
+	ns      = "default"
+)
+
+func loadResource(filePath string, resource interface{}) error {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+	err = json.Unmarshal(data, &resource)
+	if err != nil {
+		return nil
+	}
+	return err
+}
+
+func TestRegenerateReportIfExpired(t *testing.T) {
+	// clock
+	clock := ext.NewSystemClock()
+
+	// scheme
+	scheme := trivyoperator.NewScheme()
+
+	// set the VulnerabilityScannerReportTTL
+	config, err := etc.GetOperatorConfig()
+	require.NoError(t, err)
+	hours, err := time.ParseDuration("24h")
+	require.NoError(t, err)
+	config.VulnerabilityScannerReportTTL = &hours
+
+	// logger object
+	logger := log.Log.WithName("testing")
+
+	// create TTLReport controller
+	instance := vulnerabilityreport.TTLReportReconciler{Logger: logger, Config: config, Clock: clock}
+
+	tests := []struct {
+		name                  string
+		reportUpdateTimestamp time.Duration
+		ttlAnnotationMissing  bool
+		expectError           bool
+		reportDeleted         bool
+		ttlStr                string
+		invalidReportName     bool
+	}{
+		{
+			name:                  "Report timestamp < TTL",
+			reportUpdateTimestamp: -15 * 60 * time.Minute, // < 24h TTL
+			expectError:           false,
+			reportDeleted:         false,
+			ttlStr:                "24h",
+		},
+		{
+			name:                  "Report timestamp exceeds TTL",
+			reportUpdateTimestamp: -25 * 60 * time.Minute, // > 24 TTL
+			expectError:           false,
+			reportDeleted:         true, // = time.Duration(0)
+			ttlStr:                "24h",
+		},
+		{
+			name:                 "missing TTL annotation in the report",
+			ttlAnnotationMissing: true,
+			expectError:          false, // Ignoring report without TTL set
+		},
+		{
+			name:        "invalid TTL in the annotation",
+			ttlStr:      "badtime",
+			expectError: true,
+		},
+		{
+			name:              "invalid report name",
+			invalidReportName: true,
+			expectError:       false, // missing/invalid report ignored
+			reportDeleted:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// vuln report data
+			vulnReport := v1alpha1.VulnerabilityReport{}
+			if !tt.invalidReportName {
+				vulnReport.Name = vreport
+			}
+			vulnReport.Namespace = ns
+			if !tt.ttlAnnotationMissing {
+				vulnReport.Annotations = map[string]string{
+					"trivy-operator.aquasecurity.github.io/report-ttl": tt.ttlStr,
+				}
+			}
+			vulnReport.Report.UpdateTimestamp.Time = clock.Now().Add(tt.reportUpdateTimestamp)
+
+			// generate client with vulnReport
+			instance.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(&vulnReport).Build()
+
+			// Check if TTL expired for the vulnerability report
+			_, err := instance.DeleteReportIfExpired(context.TODO(), types.NamespacedName{Namespace: ns, Name: vreport})
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			vr := v1alpha1.VulnerabilityReport{}
+			err = instance.Client.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: vreport}, &vr)
+
+			if tt.reportDeleted {
+				require.Error(t, err)
+				require.True(t, apierrors.IsNotFound(err))
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Before making changes to the TTLReportReconciler, unit test the functionality

## Related issues
- related to #237

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
